### PR TITLE
Include `src` in install

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "prepublish": "npm run build"
   },
   "main": "dist/vue-at.js",
-  "files": [
-    "dist"
-  ],
   "engines": {
     "node": ">= 14.x"
   },


### PR DESCRIPTION
The latest upstream changes I pulled in explicitly defined `dist` as the only `files` entry, meaning `npm install` wouldn't include the `src` folder that we hook into from our repo.

_This fork should anyway be a stop-gap, since all it does is fix a width which we _might_ be able to do via SCSS, or won't need at all since our new `CommentInput` component might solve at-mentions in a different way, or simply install the original package._